### PR TITLE
Upgrade to latest typeset version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "gulp": "^3.9.0",
     "through2": "^2.0.0",
-    "typeset": "^0.1.4"
+    "typeset": "^0.2.2"
   },
   "devDependencies": {
     "chai": "^3.2.0",

--- a/tests/index.js
+++ b/tests/index.js
@@ -4,10 +4,33 @@ var gutil = require('gulp-util');
 var expect = require('chai').expect;
 var typeset = require('../');
 
-it('should ', function (cb) {
+it('should run', function (cb) {
 	var stream = typeset();
 	var html = '<p>"Hello," said the fox.</p>';
 	var result = '<p><span class="pull-double">“</span>Hello,” said the fox.</p>';
+  var file = new gutil.File({
+		base: __dirname,
+		path: __dirname + '/test.html',
+		contents: new Buffer(html)
+	});
+
+	stream.on('data', function (file) {
+		expect(file.contents.toString()).to.equal(result);
+	});
+
+	stream.on('end', cb);
+
+	stream.write(file);
+
+	stream.end();
+});
+
+it('should work with disable option', function (cb) {
+	var stream = typeset({
+		disable: ['ligatures']
+	});
+	var html = '<p>Ligature on first</p>';
+	var result = '<p>Ligature on first</p>';
   var file = new gutil.File({
 		base: __dirname,
 		path: __dirname + '/test.html',


### PR DESCRIPTION
Hi, I've been using this gulp plugin for a little while.

Recent versions of typeset allow a new option, `disable`. Unfortunately the typeset dependency in this package is outdated, so the `disable` option was not available.

This PR upgrades typeset to the latest version and adds a test for the `disable` option to ensure passing that option works.

Let me know if there's anything else I can do!
